### PR TITLE
Replace index.html with simple path

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <meta name="keywords" content="{{ page.keywords | join:', ' | escape }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta property="twitter:account_id" content="4503599630178231" />
-    <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+    <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'/index.html','/' }}" />
     <link rel="stylesheet" href="/css/layout.css?{{ site.data['hash'] }}"/>
     <title>{{ page.title }}</title>
     <script src="//code.jquery.com/jquery-2.1.0.min.js"></script>


### PR DESCRIPTION
Without a 301 redirect, the `/index.html` could be considered, by some search engines, a duplicate of `/`.